### PR TITLE
explicitly set pod 'imagePullPolicy' to 'Always'

### DIFF
--- a/lib/translator.js
+++ b/lib/translator.js
@@ -207,7 +207,9 @@ function convertFrom(mapping, conversion, source, initial) {
 }
 
 function csApplicationToK8SPodSpec(csAppDesc) {
-    return convertTo(CS_TO_K8S_POD_MAPPING, CS_TO_K8S_CONVERSIONS, csAppDesc);
+    return convertTo(CS_TO_K8S_POD_MAPPING, CS_TO_K8S_CONVERSIONS, csAppDesc, {
+        imagePullPolicy: 'Always'
+    });
 }
 
 function csApplicationToK8SReplicationController(csAppDesc) {


### PR DESCRIPTION
directs kuberentes to **always** attempt to pull the pod image.

I believe this is the most sane default behavior for most users, and remains consistent with the default behavior in the containership scheduler.